### PR TITLE
Remove workflow schema from nomad

### DIFF
--- a/.github/workflows/python-actions.yaml
+++ b/.github/workflows/python-actions.yaml
@@ -1,10 +1,7 @@
-name: python
-
+name: test
 on: [push]
-
 jobs:
-  build:
-
+  install-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -12,17 +9,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.9
-    - name: Check out nomad
-      uses: actions/checkout@v3
-      with:
-        repository: nomad-coe/nomad
-        path: nomad
-        submodules: true
     - name: Install dependencies
       run: |
         pip install --upgrade pip
         pip install .[tests]
-        pip install ./nomad[parsing,infrastructure]
     - name: pycodestyle
       run: |
         python -m pycodestyle --ignore=E501,E701,E731 *parsers tests

--- a/databaseparsers/openkim/metainfo/openkim.py
+++ b/databaseparsers/openkim/metainfo/openkim.py
@@ -23,6 +23,7 @@ from nomad.metainfo import (  # pylint: disable=unused-import
     Reference, JSON
 )
 from nomad.datamodel.metainfo import simulation
+import simulationworkflowschema
 
 
 m_package = Package()
@@ -114,7 +115,7 @@ class System(simulation.system.System):
         ''')
 
 
-class Elastic(simulation.workflow.Elastic):
+class Elastic(simulationworkflowschema.Elastic):
 
     m_def = Section(validate=False, extends_base_section=True)
 
@@ -127,7 +128,7 @@ class Elastic(simulation.workflow.Elastic):
         ''')
 
 
-class Phonon(simulation.workflow.Phonon):
+class Phonon(simulationworkflowschema.Phonon):
 
     m_def = Section(validate=False, extends_base_section=True)
 
@@ -140,7 +141,7 @@ class Phonon(simulation.workflow.Phonon):
         ''')
 
 
-class SimulationWorkflow(simulation.workflow.SimulationWorkflow):
+class SimulationWorkflow(simulationworkflowschema.general.SimulationWorkflow):
 
     m_def = Section(validate=False, extends_base_section=True)
 

--- a/databaseparsers/openkim/parser.py
+++ b/databaseparsers/openkim/parser.py
@@ -36,7 +36,7 @@ from nomad.datamodel.metainfo.simulation.system import System, Atoms
 from nomad.datamodel.metainfo.simulation.method import Method, ForceField, Model
 from nomad.datamodel.metainfo.simulation.calculation import (
     BandEnergies, BandStructure, Calculation, Energy, EnergyEntry, Stress, StressEntry)
-from nomad.datamodel.metainfo.simulation.workflow import (
+from simulationworkflowschema import (
     Elastic, ElasticMethod, ElasticResults, Phonon
 )
 from .metainfo import openkim  # pylint: disable=unused-import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [{ name = "The NOMAD Authors" }]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab[infrastructure]@git+https://github.com/nomad-coe/nomad.git@develop"
+    "nomad-lab[infrastructure]@git+https://github.com/nomad-coe/nomad.git@develop",
     "nomad-schema-plugin-simulation-workflow@git+https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow.git@develop",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,10 @@ description = 'Collection of NOMAD parsers for databases.'
 readme = "README.md"
 authors = [{ name = "The NOMAD Authors" }]
 license = { file = "LICENSE" }
-# dependencies = [
-#     "nomad-lab[infrastrucutre]",
-# ]
+dependencies = [
+    #"nomad-lab[infrastructure]@git+https://github.com/nomad-coe/nomad.git@develop"
+    "nomad-schema-plugin-simulation-workflow@git+https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow.git@develop",
+]
 
 [project.urls]
 homepage = "https://github.com/nomad-coe/database-parsers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 authors = [{ name = "The NOMAD Authors" }]
 license = { file = "LICENSE" }
 dependencies = [
-    #"nomad-lab[infrastructure]@git+https://github.com/nomad-coe/nomad.git@develop"
+    "nomad-lab[infrastructure]@git+https://github.com/nomad-coe/nomad.git@develop"
     "nomad-schema-plugin-simulation-workflow@git+https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow.git@develop",
 ]
 


### PR DESCRIPTION
Simulation workflow schema are moved to a plug in https://github.com/nomad-coe/nomad-schema-plugin-simulation-workflow. References to the old schema are removed.